### PR TITLE
RC-89: Added tests and got rate of play to stay the same after switching to next episode

### DIFF
--- a/RocketCast/AudioEpisodeTracker.swift
+++ b/RocketCast/AudioEpisodeTracker.swift
@@ -42,6 +42,7 @@ class AudioEpisodeTracker {
         isTheAudioEmpty = true
     }
     
+    
     static func resetAudioData() {
         audioPlayer.stop()
         currentTimerForSlider.invalidate()

--- a/RocketCast/PlayerController.swift
+++ b/RocketCast/PlayerController.swift
@@ -287,12 +287,18 @@ extension PlayerController: PlayerViewDelegate {
     let fileMgr = FileManager.default
     let path = NSHomeDirectory() + webUrl
     let file = fileMgr.contents(atPath: path)
+    let oldRate = AudioEpisodeTracker.currentRate;
     
     AudioEpisodeTracker.loadAudioDataToAudioPlayer(file!)
     albumArtwork = nil
     self.mainView?.slider.setValue(0.0, animated: false)
     self.mainView?.slider.maximumValue = Float(AudioEpisodeTracker.audioPlayer.duration)
     AudioEpisodeTracker.audioPlayer.play()
+    
+    //Reset to old rate
+    AudioEpisodeTracker.currentRate = oldRate
+    AudioEpisodeTracker.audioPlayer.rate = oldRate
+    
     mainView?.isPlaying = true
     
     let audioSession = AVAudioSession.sharedInstance()
@@ -350,6 +356,7 @@ extension PlayerController: PlayerViewDelegate {
     }
     AudioEpisodeTracker.episodeIndex += 1
     AudioEpisodeTracker.resetAudioData()
+
     self.mainView?.titleLabel.text = AudioEpisodeTracker.getCurrentEpisode().title
     
     self.downloadAudioEpisode()

--- a/RocketCastUITests/PlayerUITests.swift
+++ b/RocketCastUITests/PlayerUITests.swift
@@ -99,9 +99,11 @@ class PlayerUITests: BaseUITest {
         app.staticTexts[SamplePodcast.podcastTitle].tap()
         
         let tablesQuery = app.tables
+        let mondayMorningPodcast91216StaticText = tablesQuery.staticTexts[SamplePodcast.firstEpisode]
         tablesQuery.staticTexts[SamplePodcast.firstEpisode].tap()
         // Go to the first episode
         clickAndDownloadEpisode(episodeTitle: SamplePodcast.firstEpisode)
+        mondayMorningPodcast91216StaticText.tap()
         
         XCTAssert(app.staticTexts[SamplePodcast.firstEpisode].exists)
         let doesItExist = NSPredicate(format: "exists == true")
@@ -121,6 +123,51 @@ class PlayerUITests: BaseUITest {
         XCTAssertFalse(normalSliderPositionValue.exists)
         expectation(for: doesItExist, evaluatedWith: normalSliderPositionValue, handler: nil)
         waitForExpectations(timeout: timeOut, handler: nil)
+        
+    }
+    
+    
+    func testSpeedRateSavedInNextEpisode() {
+        
+        getPodcastBySeguingToUrl()
+        let app = XCUIApplication()
+        
+        app.staticTexts[SamplePodcast.podcastTitle].tap()
+        
+        let tablesQuery = app.tables
+        let mondayMorningPodcast91216StaticText = tablesQuery.staticTexts[SamplePodcast.firstEpisode]
+        tablesQuery.staticTexts[SamplePodcast.firstEpisode].tap()
+        // Go to the first episode
+        clickAndDownloadEpisode(episodeTitle: SamplePodcast.firstEpisode)
+        mondayMorningPodcast91216StaticText.tap()
+        
+        XCTAssert(app.staticTexts[SamplePodcast.firstEpisode].exists)
+        let doesItExist = NSPredicate(format: "exists == true")
+        let normalSliderPositionValue =  app.sliders["1%"]
+        XCTAssertFalse(normalSliderPositionValue.exists)
+        expectation(for: doesItExist, evaluatedWith: normalSliderPositionValue, handler: nil)
+        waitForExpectations(timeout: timeOut, handler: nil)
+        
+        XCTAssert(app.buttons[play2TimesButton].exists)
+        app.buttons[play2TimesButton].tap()
+        let playingAt2xStaticText = app.staticTexts["Playing at 2x"]
+        XCTAssert(playingAt2xStaticText.exists)
+        
+        // move the slider to the end, which should go to the next episode
+        app.sliders.element.adjust(toNormalizedSliderPosition: 0.99)
+        let successAlert = app.alerts["Success"]
+        XCTAssertFalse(successAlert.exists)
+        
+        expectation(for: doesItExist, evaluatedWith: successAlert, handler: nil)
+        waitForExpectations(timeout: timeOut, handler: nil)
+        successAlert.buttons["Ok"].tap()
+        XCTAssert(app.staticTexts[SamplePodcast.secondEpisode].exists)
+        XCTAssertFalse(normalSliderPositionValue.exists)
+        expectation(for: doesItExist, evaluatedWith: normalSliderPositionValue, handler: nil)
+        waitForExpectations(timeout: timeOut, handler: nil)
+        
+        //Check to see if rate has been preserved
+        XCTAssert(playingAt2xStaticText.exists)
         
     }
     


### PR DESCRIPTION
### Fixes issue: RC-89

### Summary of fix
- Got rate of play to stay the same after switching to next episode
- Added UITest to check that rate is preserved

Checklist:
- [x] Builds on your computer
- [x] Merging to **dev** and NOT master
- [x] Travis CI passes
- [x] Created new tests if needed
- [x] Modified tests if needed

